### PR TITLE
Add vscode default shell setting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
   "dockerComposeFile": "docker-compose.yml",
   "extensions": ["lfs.vscode-emacs-friendly", "james-yu.latex-workshop"],
   "service": "texlive-ja",
+  "settings": {
+    "terminal.integrated.shell": "/bin/bash"
+  },
   "workspaceFolder": "/workdir",
   "shutdownAction": "stopCompose"
 }


### PR DESCRIPTION
ありがたく利用させてもらっています。
macOSで利用しているのですが、デフォルトシェルが`/bin/zsh`になっているのでremote containerで開いてる状態でvscode上のターミナルを開こうとするとzshが見つからないと言われてしまったので、追加のセッティングを導入したところ直りました。もし必要でしたらマージしていただければと。