### PR TITLE
コンテナ内からgithubにpushする際のCAエラーの対策

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 FROM nukopy/ubuntu-texlive-ja:latest
-
+RUN apt update && apt install --reinstall ca-certificates -y
 CMD ["/bin/bash"]


### PR DESCRIPTION
## 問題
[本レポジトリ](https://github.com/nukopy/latex-in-docker-on-vscode)をクローンやテンプレートとして利用後，VSCodeでコンテナ内からgithubにpush等を行う際，以下のCAエラー（証明書周りのエラー）が発生する．

```
fatal: unable to access 'https://github.com/yasaidev/latex-in-docker-on-vscode/': server certificate verification failed. CAfile: none CRLfile: none
```

## 原因

以下リンクで解説されている．おそらく証明書周りが最新でない可能性がある．

https://qiita.com/shimacpyon/items/1af6d1ed69f6ad54c73c

## 対処

dockerfileのRUNコマンドに以下を追加して，最新の証明書をインストールするようにした．
```bash
apt update && apt install --reinstall ca-certificates -y
```