### PR TITLE
fix: change path to latexindent

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
         "env": {}
       }
     ],
-    "latex-workshop.latexindent.path": "/usr/local/texlive/2020/bin/x86_64-linux/latexindent",
+    "latex-workshop.latexindent.path": "/usr/local/texlive/2022/bin/x86_64-linux/latexindent",
     "latex-workshop.message.update.show": false,
     "latex-workshop.synctex.afterBuild.enabled": true,
     "latex-workshop.view.pdf.viewer": "tab"


### PR DESCRIPTION
# 問題
vscode上でフォーマットを行うと, 
latexindentのパスが正しくないという旨のエラーが表示され自動フォーマットが実行されないようです.  
# 原因
#5 でTexLiveのバージョンを2022へ変更した際に, latexindentのパスも変わったようです. 
# 対処
devcontainer.json内の`latex-workshop.latexindent.path`を2020から2022へ書き換えました. 